### PR TITLE
Use image stored in SiEPICfab-EBeam-ZEP-PDK instead of jasminabrar

### DIFF
--- a/.github/workflows/ZEP_Tests.yml
+++ b/.github/workflows/ZEP_Tests.yml
@@ -29,10 +29,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull zep_siepic_klayout image
-        run: docker pull ghcr.io/jasminabrar/siepicfab-ebeam-zep-pdk/zep_siepic_klayout:master-latest
+        run: docker pull ghcr.io/siepic/siepicfab-ebeam-zep-pdk/zep_siepic_klayout:master-latest
 
       - name: Run docker container from image
-        run: docker run -itd --name zep_test -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --security-opt label=type:container_runtime_t ghcr.io/jasminabrar/siepicfab-ebeam-zep-pdk/zep_siepic_klayout:master-latest
+        run: docker run -itd --name zep_test -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --security-opt label=type:container_runtime_t ghcr.io/siepic/siepicfab-ebeam-zep-pdk/zep_siepic_klayout:master-latest
 
       - name: Copy pymacros folder to docker container
         run: docker cp $GITHUB_WORKSPACE/SiEPICfab_EBeam_ZEP/pymacros zep_test:/home/pymacros

--- a/.github/workflows/ZEP_Tests.yml
+++ b/.github/workflows/ZEP_Tests.yml
@@ -21,6 +21,13 @@ jobs:
             repository: ${{ github.repository_owner }}/SiEPICfab-EBeam-ZEP-PDK
             ref: ${{ github.ref }}
 
+      - name: Connect to Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull zep_siepic_klayout image
         run: docker pull ghcr.io/jasminabrar/siepicfab-ebeam-zep-pdk/zep_siepic_klayout:master-latest
 

--- a/.github/workflows/ZEP_Tests.yml
+++ b/.github/workflows/ZEP_Tests.yml
@@ -46,7 +46,7 @@ jobs:
 
           if [ "${{ github.repository }}" == "${{ env.GITHUB_REPOSITORY }}" ]; then
             # If we are in the main repository, copy all contents of siepicfab ebeam zep folder to docker container 
-            docker exec ebeam_test rm -r /root/Github/SiEPICfab-EBeam-ZEP-PDK/SiEPICfab_EBeam_ZEP/*
+            docker exec zep_test rm -r /root/Github/SiEPICfab-EBeam-ZEP-PDK/SiEPICfab_EBeam_ZEP/*
             docker cp $GITHUB_WORKSPACE/SiEPICfab_EBeam_ZEP/. zep_test:/root/Github/SiEPICfab-EBeam-ZEP-PDK/SiEPICfab_EBeam_ZEP/
           else 
             # If we are in a forked repository or another branch, copy changed files to zep_test


### PR DESCRIPTION
- use siepic instead of jasminabrar, add container login to avoid unauthorized error
- tested it on my forked repo by turning my package to private and the container login made it work