### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/grain.xml
+++ b/grain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <salt-grain>
  <name>siepicfab_ebeam_zep_pdk</name>
- <version>0.1.6</version>
+ <version>0.1.7</version>
  <api-version>0.27</api-version>
  <title>SiEPICfab EBeam ZEP PDK</title>
  <doc>A Process Design Kit for Silicon Photonics fabricated using Electron Beam Lithography, using ZEP resist</doc>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ packages = [
 
 [project]
 name = "siepicfab_ebeam_zep"
-version = "0.1.6"
+version = "0.1.7"
 authors = [
   { name="Lukas Chrostowski", email="lukasc@ece.ubc.ca" },
 ]

--- a/siepicfab_ebeam_zep/pymacros/__init__.py
+++ b/siepicfab_ebeam_zep/pymacros/__init__.py
@@ -1,6 +1,6 @@
 # $autorun
 
-version = "0.1.6"
+version = "0.1.7"
 
 print('SiEPICfab-EBeam-ZEP Python module: pymacros, v%s' % version)
 


### PR DESCRIPTION
Update project version for a new patch release. Incremented version strings from 0.1.6 to 0.1.7 in grain.xml, pyproject.toml, and siepicfab_ebeam_zep/pymacros/__init__.py.